### PR TITLE
RES-27: Add File Sequence Image Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,6 @@
 # EKF Mono SLAM
-> EKF Mono SLAM written in modern C++
 
-TBD
+## Datasets
 
-## Installation
-
-TBD
-
-## Usage example
-
-TBD
-
-## Development setup
-
-TBD
-
-## Meta
-
-Álvaro Joaquín Gaona – [@alvgaona](https://twitter.com/alvgaona) – alvgaona@gmail.com
-
-![MIT License][mit-image]
-
-Distributed under the MIT License. See  for more information.
-
-## Contributing
-
-TBD
-
-<!-- Markdown link & img dfn's -->
-[mit-image]: https://img.shields.io/badge/license-MIT-green
+- [AGZ Subset](https://pub-db0cd070a4f94dabb9b58161850d4868.r2.dev/AGZ_subset.zip)
+- [Desk Translation](https://pub-db0cd070a4f94dabb9b58161850d4868.r2.dev/desk_translation.zip)

--- a/src/ekf-mono-slam/CMakeLists.txt
+++ b/src/ekf-mono-slam/CMakeLists.txt
@@ -53,6 +53,11 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
 if(BUILD_TESTING)
   file(GLOB_RECURSE TEST_SOURCES test/*.cpp)
   file(GLOB_RECURSE SOURCES_FOR_TESTS src/*.cpp)

--- a/src/ekf-mono-slam/CMakeLists.txt
+++ b/src/ekf-mono-slam/CMakeLists.txt
@@ -13,6 +13,8 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(cv_bridge REQUIRED)
 find_package(Eigen3 3.4.0 REQUIRED)
 find_package(OpenCV 4.9.0 REQUIRED)
 find_package(spdlog 1.12.0 REQUIRED)
@@ -24,7 +26,7 @@ file(GLOB_RECURSE IMAGE_SOURCES src/image/*.cpp)
 
 
 add_executable(file_sequence_image src/file_sequence_image_node.cpp ${MATH_SOURCES} ${CONFIG_SOURCES} ${IMAGE_SOURCES})
-ament_target_dependencies(file_sequence_image PUBLIC rclcpp std_msgs)
+ament_target_dependencies(file_sequence_image PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
 target_link_libraries(file_sequence_image PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog)
 target_include_directories(file_sequence_image
   PUBLIC
@@ -35,7 +37,7 @@ target_include_directories(file_sequence_image
 )
 
 add_executable(ekf src/ekf_node.cpp)
-ament_target_dependencies(ekf PUBLIC rclcpp std_msgs)
+ament_target_dependencies(ekf PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
 target_link_libraries(ekf PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog)
 target_include_directories(ekf
   PUBLIC

--- a/src/ekf-mono-slam/include/file_sequence_image_node.h
+++ b/src/ekf-mono-slam/include/file_sequence_image_node.h
@@ -14,7 +14,7 @@ class FileSequenceImageNode : public rclcpp::Node {
  private:
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher_;
-  FileSequenceImageProvider image_provider_;
+  std::unique_ptr<FileSequenceImageProvider> image_provider_;
 
   void timer_callback();
 };

--- a/src/ekf-mono-slam/include/file_sequence_image_node.h
+++ b/src/ekf-mono-slam/include/file_sequence_image_node.h
@@ -1,7 +1,9 @@
 #ifndef FILE_SEQUENCE_IMAGE_NODE_MONO_SLAM_EKF_H
 #define FILE_SEQUENCE_IMAGE_NODE_MONO_SLAM_EKF_H
 
+#include "image/file_sequence_image_provider.h"
 #include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/string.hpp"
 
 class FileSequenceImageNode : public rclcpp::Node {
@@ -11,8 +13,8 @@ class FileSequenceImageNode : public rclcpp::Node {
 
  private:
   rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
-  size_t count_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher_;
+  FileSequenceImageProvider image_provider_;
 
   void timer_callback();
 };

--- a/src/ekf-mono-slam/include/image/file_sequence_image_provider.h
+++ b/src/ekf-mono-slam/include/image/file_sequence_image_provider.h
@@ -2,6 +2,7 @@
 #define EKF_MONO_SLAM_FILE_SEQUENCE_IMAGE_PROVIDER_H_
 
 #include <filesystem>
+#include <memory>
 #include <string>
 
 #include "image_file_format.h"

--- a/src/ekf-mono-slam/launch/vslam.launch.py
+++ b/src/ekf-mono-slam/launch/vslam.launch.py
@@ -1,0 +1,24 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "image_dir", default_value="./resources/desk_translation/"
+            ),
+            Node(
+                package="ekf-mono-slam",
+                executable="file_sequence_image",
+                name="file_sequence_image",
+                output="screen",
+                parameters=[
+                    {"image_dir": LaunchConfiguration("image_dir")},
+                ],
+                arguments=["--ros-args", "--log-level", "warn"],
+            ),
+        ]
+    )

--- a/src/ekf-mono-slam/src/file_sequence_image_node.cpp
+++ b/src/ekf-mono-slam/src/file_sequence_image_node.cpp
@@ -6,20 +6,27 @@
 #include <memory>
 #include <string>
 
+#include "cv_bridge/cv_bridge.h"
+
 using namespace std::chrono_literals;
 
-FileSequenceImageNode::FileSequenceImageNode() : Node("file_sequence_image"), count_(0) {
-  publisher_ = this->create_publisher<std_msgs::msg::String>("slam/ekf/step", 10);
-  timer_ = this->create_wall_timer(500ms, std::bind(&FileSequenceImageNode::timer_callback, this));
+FileSequenceImageNode::FileSequenceImageNode()
+    : Node("file_sequence_image"), image_provider_("./resources/desk_translation/", 1, 359) {
+  publisher_ = this->create_publisher<sensor_msgs::msg::Image>("slam/ekf/step", 10);
+  timer_ = this->create_wall_timer(40ms, std::bind(&FileSequenceImageNode::timer_callback, this));
 }
 
 void FileSequenceImageNode::timer_callback() {
-  Eigen::Vector2i v(1, 2);
-  Eigen::Vector2i w(1, 2);
-  auto message = std_msgs::msg::String();
-  message.data = "The result is " + std::to_string(v.dot(w));
-  RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", message.data.c_str());
-  publisher_->publish(message);
+  cv::Mat image = image_provider_.GetNextImage();
+
+  cv_bridge::CvImage cv_bridge_image;
+  cv_bridge_image.encoding = sensor_msgs::image_encodings::BGR8;
+  cv_bridge_image.image = image;
+
+  sensor_msgs::msg::Image::SharedPtr image_msg =
+      cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", image).toImageMsg();
+
+  publisher_->publish(*image_msg);
 }
 
 int main(int argc, char *argv[]) {

--- a/src/ekf-mono-slam/src/file_sequence_image_node.cpp
+++ b/src/ekf-mono-slam/src/file_sequence_image_node.cpp
@@ -10,14 +10,17 @@
 
 using namespace std::chrono_literals;
 
-FileSequenceImageNode::FileSequenceImageNode()
-    : Node("file_sequence_image"), image_provider_("./resources/desk_translation/", 1, 359) {
+FileSequenceImageNode::FileSequenceImageNode() : Node("file_sequence_image") {
+  this->declare_parameter("image_dir", "");
+  auto image_dir = this->get_parameter("image_dir").get_value<std::string>();
+
+  image_provider_ = std::make_unique<FileSequenceImageProvider>(image_dir, 1, 359);
   publisher_ = this->create_publisher<sensor_msgs::msg::Image>("slam/ekf/step", 10);
   timer_ = this->create_wall_timer(40ms, std::bind(&FileSequenceImageNode::timer_callback, this));
 }
 
 void FileSequenceImageNode::timer_callback() {
-  cv::Mat image = image_provider_.GetNextImage();
+  cv::Mat image = image_provider_->GetNextImage();
 
   cv_bridge::CvImage cv_bridge_image;
   cv_bridge_image.encoding = sensor_msgs::image_encodings::BGR8;

--- a/src/ekf-mono-slam/src/image/file_sequence_image_provider.cpp
+++ b/src/ekf-mono-slam/src/image/file_sequence_image_provider.cpp
@@ -39,6 +39,7 @@ FileSequenceImageProvider::FileSequenceImageProvider(const std::string& director
 cv::Mat FileSequenceImageProvider::GetNextImage() {
   if (image_counter_ > end_index_ - start_index_) {
     spdlog::warn("No more images in directory");
+    return cv::Mat();
   }
 
   std::stringstream image_number;


### PR DESCRIPTION
- Integrate `FileSequenceImageProvider` into the node.
- Publish the image read from a directory as an `sensor_msgs::msg::Image` using `cv_bridge` in BGR8.
- Configure a launch file to read parameters, such as the image directory from where to read images.