### PR TITLE
RES-26: Create EKF node

### DIFF
--- a/src/ekf-mono-slam/CMakeLists.txt
+++ b/src/ekf-mono-slam/CMakeLists.txt
@@ -24,8 +24,7 @@ file(GLOB_RECURSE MATH_SOURCES src/math/*.cpp)
 file(GLOB_RECURSE FILTER_SOURCES src/filter/*.cpp)
 file(GLOB_RECURSE IMAGE_SOURCES src/image/*.cpp)
 
-
-add_executable(file_sequence_image src/file_sequence_image_node.cpp ${MATH_SOURCES} ${CONFIG_SOURCES} ${IMAGE_SOURCES})
+add_executable(file_sequence_image src/file_sequence_image_node.cpp ${CONFIG_SOURCES} ${IMAGE_SOURCES})
 ament_target_dependencies(file_sequence_image PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
 target_link_libraries(file_sequence_image PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog)
 target_include_directories(file_sequence_image
@@ -33,7 +32,6 @@ target_include_directories(file_sequence_image
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   ${OpenCV_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
 )
 
 add_executable(ekf src/ekf_node.cpp)

--- a/src/ekf-mono-slam/CMakeLists.txt
+++ b/src/ekf-mono-slam/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
+find_package(image_transport REQUIRED)
 find_package(Eigen3 3.4.0 REQUIRED)
 find_package(OpenCV 4.9.0 REQUIRED)
 find_package(spdlog 1.12.0 REQUIRED)
@@ -25,7 +26,7 @@ file(GLOB_RECURSE FILTER_SOURCES src/filter/*.cpp)
 file(GLOB_RECURSE IMAGE_SOURCES src/image/*.cpp)
 
 add_executable(file_sequence_image src/file_sequence_image_node.cpp ${CONFIG_SOURCES} ${IMAGE_SOURCES})
-ament_target_dependencies(file_sequence_image PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
+ament_target_dependencies(file_sequence_image PUBLIC rclcpp std_msgs sensor_msgs cv_bridge image_transport)
 target_link_libraries(file_sequence_image PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog)
 target_include_directories(file_sequence_image
   PUBLIC
@@ -35,7 +36,7 @@ target_include_directories(file_sequence_image
 )
 
 add_executable(ekf src/ekf_node.cpp)
-ament_target_dependencies(ekf PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
+ament_target_dependencies(ekf PUBLIC rclcpp std_msgs sensor_msgs cv_bridge image_transport)
 target_link_libraries(ekf PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog)
 target_include_directories(ekf
   PUBLIC

--- a/src/ekf-mono-slam/include/ekf_node.h
+++ b/src/ekf-mono-slam/include/ekf_node.h
@@ -1,6 +1,6 @@
-#ifndef EKF_NODE_MONO_SLAM_EKF_H
-#define EKF_NODE_MONO_SLAM_EKF_H
+#pragma once
 
+#include "image_transport/image_transport.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -11,9 +11,7 @@ class EKFNode : public rclcpp::Node {
   ~EKFNode() = default;
 
  private:
-  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr subscription_;
+  std::shared_ptr<image_transport::Subscriber> image_subscriber_;
 
-  void step_callback(sensor_msgs::msg::Image::SharedPtr msg);
+  void step_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg);
 };
-
-#endif /* EKF_NODE_MONO_SLAM_EKF_H */

--- a/src/ekf-mono-slam/include/ekf_node.h
+++ b/src/ekf-mono-slam/include/ekf_node.h
@@ -2,6 +2,7 @@
 #define EKF_NODE_MONO_SLAM_EKF_H
 
 #include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/string.hpp"
 
 class EKFNode : public rclcpp::Node {
@@ -10,9 +11,9 @@ class EKFNode : public rclcpp::Node {
   ~EKFNode() = default;
 
  private:
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr subscription_;
 
-  void step_callback(std_msgs::msg::String::UniquePtr msg);
+  void step_callback(sensor_msgs::msg::Image::SharedPtr msg);
 };
 
 #endif /* EKF_NODE_MONO_SLAM_EKF_H */

--- a/src/ekf-mono-slam/include/file_sequence_image_node.h
+++ b/src/ekf-mono-slam/include/file_sequence_image_node.h
@@ -1,7 +1,7 @@
-#ifndef FILE_SEQUENCE_IMAGE_NODE_MONO_SLAM_EKF_H
-#define FILE_SEQUENCE_IMAGE_NODE_MONO_SLAM_EKF_H
+#pragma once
 
 #include "image/file_sequence_image_provider.h"
+#include "image_transport/image_transport.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -13,10 +13,8 @@ class FileSequenceImageNode : public rclcpp::Node {
 
  private:
   rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher_;
+  std::shared_ptr<image_transport::Publisher> image_publisher_;
   std::unique_ptr<FileSequenceImageProvider> image_provider_;
 
   void timer_callback();
 };
-
-#endif /* FILE_SEQUENCE_IMAGE_NODE_MONO_SLAM_EKF_H */

--- a/src/ekf-mono-slam/include/image/file_sequence_image_provider.h
+++ b/src/ekf-mono-slam/include/image/file_sequence_image_provider.h
@@ -1,5 +1,4 @@
-#ifndef EKF_MONO_SLAM_FILE_SEQUENCE_IMAGE_PROVIDER_H_
-#define EKF_MONO_SLAM_FILE_SEQUENCE_IMAGE_PROVIDER_H_
+#pragma once
 
 #include <filesystem>
 #include <memory>
@@ -24,5 +23,3 @@ class FileSequenceImageProvider final : public ImageProvider {
   int image_counter_;
   ImageFileFormat image_type_;
 };
-
-#endif /* EKF_MONO_SLAM_FILE_SEQUENCE_IMAGE_PROVIDER_H_ */

--- a/src/ekf-mono-slam/launch/vslam.launch.py
+++ b/src/ekf-mono-slam/launch/vslam.launch.py
@@ -14,6 +14,7 @@ def generate_launch_description():
                 package="ekf-mono-slam",
                 executable="file_sequence_image",
                 name="file_sequence_image",
+                namespace="slam",
                 output="screen",
                 parameters=[
                     {"image_dir": LaunchConfiguration("image_dir")},

--- a/src/ekf-mono-slam/src/ekf_node.cpp
+++ b/src/ekf-mono-slam/src/ekf_node.cpp
@@ -5,17 +5,17 @@
 #include "cv_bridge/cv_bridge.h"
 
 EKFNode::EKFNode() : Node("ekf_node") {
-  subscription_ = this->create_subscription<sensor_msgs::msg::Image>(
-      "camera/image", 10, std::bind(&EKFNode::step_callback, this, std::placeholders::_1));
+  image_subscriber_ = std::make_shared<image_transport::Subscriber>(image_transport::create_subscription(
+      this, "camera/image", std::bind(&EKFNode::step_callback, this, std::placeholders::_1), "raw"));
 }
 
-void EKFNode::step_callback(sensor_msgs::msg::Image::SharedPtr msg) {
+void EKFNode::step_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg) {
   cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
   cv::Mat image = cv_ptr->image;
   RCLCPP_INFO(this->get_logger(), "Image size '%d'", image.size().width);
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
   rclcpp::spin(std::make_shared<EKFNode>());
   rclcpp::shutdown();

--- a/src/ekf-mono-slam/src/ekf_node.cpp
+++ b/src/ekf-mono-slam/src/ekf_node.cpp
@@ -2,13 +2,17 @@
 
 #include <memory>
 
+#include "cv_bridge/cv_bridge.h"
+
 EKFNode::EKFNode() : Node("ekf_node") {
-  subscription_ = this->create_subscription<std_msgs::msg::String>(
-      "slam/ekf/step", 10, std::bind(&EKFNode::step_callback, this, std::placeholders::_1));
+  subscription_ = this->create_subscription<sensor_msgs::msg::Image>(
+      "camera/image", 10, std::bind(&EKFNode::step_callback, this, std::placeholders::_1));
 }
 
-void EKFNode::step_callback(std_msgs::msg::String::UniquePtr msg) {
-  RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
+void EKFNode::step_callback(sensor_msgs::msg::Image::SharedPtr msg) {
+  cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+  cv::Mat image = cv_ptr->image;
+  RCLCPP_INFO(this->get_logger(), "Image size '%d'", image.size().width);
 }
 
 int main(int argc, char *argv[]) {

--- a/src/ekf-mono-slam/src/file_sequence_image_node.cpp
+++ b/src/ekf-mono-slam/src/file_sequence_image_node.cpp
@@ -14,7 +14,8 @@ FileSequenceImageNode::FileSequenceImageNode() : Node("file_sequence_image") {
   auto image_dir = this->get_parameter("image_dir").get_value<std::string>();
 
   image_provider_ = std::make_unique<FileSequenceImageProvider>(image_dir, 1, 359);
-  publisher_ = this->create_publisher<sensor_msgs::msg::Image>("camera/image", 10);
+  image_publisher_ =
+      std::make_shared<image_transport::Publisher>(image_transport::create_publisher(this, "camera/image"));
   timer_ = this->create_wall_timer(40ms, std::bind(&FileSequenceImageNode::timer_callback, this));
 }
 
@@ -28,7 +29,7 @@ void FileSequenceImageNode::timer_callback() {
   sensor_msgs::msg::Image::SharedPtr image_msg =
       cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", image).toImageMsg();
 
-  publisher_->publish(*image_msg);
+  image_publisher_->publish(*image_msg);
 }
 
 int main(int argc, char *argv[]) {

--- a/src/ekf-mono-slam/src/file_sequence_image_node.cpp
+++ b/src/ekf-mono-slam/src/file_sequence_image_node.cpp
@@ -1,6 +1,5 @@
 #include "file_sequence_image_node.h"
 
-#include <Eigen/Dense>
 #include <chrono>
 #include <functional>
 #include <memory>
@@ -15,7 +14,7 @@ FileSequenceImageNode::FileSequenceImageNode() : Node("file_sequence_image") {
   auto image_dir = this->get_parameter("image_dir").get_value<std::string>();
 
   image_provider_ = std::make_unique<FileSequenceImageProvider>(image_dir, 1, 359);
-  publisher_ = this->create_publisher<sensor_msgs::msg::Image>("slam/ekf/step", 10);
+  publisher_ = this->create_publisher<sensor_msgs::msg::Image>("camera/image", 10);
   timer_ = this->create_wall_timer(40ms, std::bind(&FileSequenceImageNode::timer_callback, this));
 }
 


### PR DESCRIPTION
- Subscribe EKF node to an image topic, i.e., `camera/image`
- Remove unused dependencies from `file_sequence_image_node`.
- Use `image_transport` to send images over the wire.
- Adapt `FileSequenceImageNode` to standardize for `image_transport`.