### PR TITLE
RES-28: Come up with first EKF initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Other
+resources/
+
 # ROS
 install/
 log/

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,9 +7,8 @@ channels = ["conda-forge", "robostack-staging"]
 platforms = ["osx-64", "linux-64"]
 
 [tasks]
-build = "colcon build --symlink-install --event-handler console_direct+ --cmake-args -G Ninja -DPython_EXECUTABLE='$CONDA_PREFIX/bin/python' -DPython3_EXECUTABLE='$CONDA_PREFIX/bin/python'"
+build = "colcon build --symlink-install --event-handler console_direct+ --cmake-args -G Ninja -DPython_EXECUTABLE=$CONDA_PREFIX/bin/python -DPython3_EXECUTABLE=$CONDA_PREFIX/bin/python"
 test = "colcon test --ctest-args tests ekf_mono_slam && ./build/ekf_mono_slam/some_test"
-some = "echo $CONDA_PREFIX"
 
 [dependencies]
 ros-humble-desktop = ">=0.10.0,<0.11"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ekf-mono-slam"
+name = "ekf_mono_slam"
 version = "0.1.0"
 description = "Visual Mono SLAM with 1-Point RANSAC EKF"
 authors = ["Alvaro <agaona@asapp.com>"]
@@ -7,8 +7,9 @@ channels = ["conda-forge", "robostack-staging"]
 platforms = ["osx-64", "linux-64"]
 
 [tasks]
-build = "colcon build --symlink-install --event-handler console_direct+"
-test = "colcon test --ctest-args tests ekf-mono-slam && ./build/ekf-mono-slam/some_test"
+build = "colcon build --symlink-install --event-handler console_direct+ --cmake-args -G Ninja -DPython_EXECUTABLE='$CONDA_PREFIX/bin/python' -DPython3_EXECUTABLE='$CONDA_PREFIX/bin/python'"
+test = "colcon test --ctest-args tests ekf_mono_slam && ./build/ekf_mono_slam/some_test"
+some = "echo $CONDA_PREFIX"
 
 [dependencies]
 ros-humble-desktop = ">=0.10.0,<0.11"

--- a/src/ekf-mono-slam/CMakeLists.txt
+++ b/src/ekf-mono-slam/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(ekf-mono-slam)
+project(ekf_mono_slam)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 20)
@@ -19,6 +19,7 @@ find_package(image_transport REQUIRED)
 find_package(Eigen3 3.4.0 REQUIRED)
 find_package(OpenCV 4.9.0 REQUIRED)
 find_package(spdlog 1.12.0 REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 
 file(GLOB_RECURSE CONFIG_SOURCES src/configuration/*.cpp)
 file(GLOB_RECURSE MATH_SOURCES src/math/*.cpp)
@@ -35,7 +36,7 @@ target_include_directories(file_sequence_image
   ${OpenCV_INCLUDE_DIRS}
 )
 
-add_executable(ekf src/ekf_node.cpp)
+add_executable(ekf src/ekf_node.cpp ${FILTER_SOURCES} ${MATH_SOURCES})
 ament_target_dependencies(ekf PUBLIC rclcpp std_msgs sensor_msgs cv_bridge image_transport)
 target_link_libraries(ekf PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog)
 target_include_directories(ekf
@@ -56,6 +57,13 @@ install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME}
 )
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/ImageFeatureMeasurement.msg"
+  "srv/FeatureDetector.srv"
+  DEPENDENCIES sensor_msgs
+ )
+
 
 if(BUILD_TESTING)
   file(GLOB_RECURSE TEST_SOURCES test/*.cpp)

--- a/src/ekf-mono-slam/CMakeLists.txt
+++ b/src/ekf-mono-slam/CMakeLists.txt
@@ -25,6 +25,24 @@ file(GLOB_RECURSE CONFIG_SOURCES src/configuration/*.cpp)
 file(GLOB_RECURSE MATH_SOURCES src/math/*.cpp)
 file(GLOB_RECURSE FILTER_SOURCES src/filter/*.cpp)
 file(GLOB_RECURSE IMAGE_SOURCES src/image/*.cpp)
+file(GLOB_RECURSE FEATURE_SOURCES src/feature/*.cpp)
+
+set(MSG_FILES
+  "msg/ImageFeatureMeasurement.msg"
+  "msg/ImageFeaturePrediction.msg"
+)
+
+set(SRV_FILES
+  "srv/FeatureDetector.srv"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${MSG_FILES}
+  ${SRV_FILES}
+  DEPENDENCIES sensor_msgs
+)
+
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} rosidl_typesupport_cpp)
 
 add_executable(file_sequence_image src/file_sequence_image_node.cpp ${CONFIG_SOURCES} ${IMAGE_SOURCES})
 ament_target_dependencies(file_sequence_image PUBLIC rclcpp std_msgs sensor_msgs cv_bridge image_transport)
@@ -36,9 +54,20 @@ target_include_directories(file_sequence_image
   ${OpenCV_INCLUDE_DIRS}
 )
 
+add_executable(feature_detector src/feature_detector_node.cpp ${FEATURE_SOURCES})
+ament_target_dependencies(feature_detector PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
+target_link_libraries(feature_detector PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog ${cpp_typesupport_target})
+target_include_directories(feature_detector
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  ${OpenCV_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
+)
+
 add_executable(ekf src/ekf_node.cpp ${FILTER_SOURCES} ${MATH_SOURCES})
 ament_target_dependencies(ekf PUBLIC rclcpp std_msgs sensor_msgs cv_bridge image_transport)
-target_link_libraries(ekf PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog)
+target_link_libraries(ekf PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog ${cpp_typesupport_target})
 target_include_directories(ekf
   PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -50,6 +79,7 @@ target_include_directories(ekf
 install(TARGETS
   file_sequence_image
   ekf
+  feature_detector
   DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -57,13 +87,6 @@ install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME}
 )
-
-rosidl_generate_interfaces(${PROJECT_NAME}
-  "msg/ImageFeatureMeasurement.msg"
-  "srv/FeatureDetector.srv"
-  DEPENDENCIES sensor_msgs
- )
-
 
 if(BUILD_TESTING)
   file(GLOB_RECURSE TEST_SOURCES test/*.cpp)

--- a/src/ekf-mono-slam/CMakeLists.txt
+++ b/src/ekf-mono-slam/CMakeLists.txt
@@ -21,30 +21,31 @@ find_package(OpenCV 4.9.0 REQUIRED)
 find_package(spdlog 1.12.0 REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-file(GLOB_RECURSE CONFIG_SOURCES src/configuration/*.cpp)
-file(GLOB_RECURSE MATH_SOURCES src/math/*.cpp)
-file(GLOB_RECURSE FILTER_SOURCES src/filter/*.cpp)
-file(GLOB_RECURSE IMAGE_SOURCES src/image/*.cpp)
-file(GLOB_RECURSE FEATURE_SOURCES src/feature/*.cpp)
+file(GLOB_RECURSE config_src src/configuration/*.cpp)
+file(GLOB_RECURSE math_src src/math/*.cpp)
+file(GLOB_RECURSE filter_src src/filter/*.cpp)
+file(GLOB_RECURSE image_src src/image/*.cpp)
+file(GLOB_RECURSE feature_src src/feature/*.cpp)
+file(GLOB_RECURSE visual_src src/visual/*.cpp)
 
-set(MSG_FILES
+set(msg_files
   "msg/ImageFeatureMeasurement.msg"
   "msg/ImageFeaturePrediction.msg"
 )
 
-set(SRV_FILES
+set(srv_files
   "srv/FeatureDetector.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}
-  ${MSG_FILES}
-  ${SRV_FILES}
+  ${msg_files}
+  ${srv_files}
   DEPENDENCIES sensor_msgs
 )
 
 rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} rosidl_typesupport_cpp)
 
-add_executable(file_sequence_image src/file_sequence_image_node.cpp ${CONFIG_SOURCES} ${IMAGE_SOURCES})
+add_executable(file_sequence_image src/file_sequence_image_node.cpp ${config_src} ${image_src})
 ament_target_dependencies(file_sequence_image PUBLIC rclcpp std_msgs sensor_msgs cv_bridge image_transport)
 target_link_libraries(file_sequence_image PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog)
 target_include_directories(file_sequence_image
@@ -54,7 +55,7 @@ target_include_directories(file_sequence_image
   ${OpenCV_INCLUDE_DIRS}
 )
 
-add_executable(feature_detector src/feature_detector_node.cpp ${FEATURE_SOURCES})
+add_executable(feature_detector src/feature_detector_node.cpp ${feature_src} ${visual_src})
 ament_target_dependencies(feature_detector PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
 target_link_libraries(feature_detector PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog ${cpp_typesupport_target})
 target_include_directories(feature_detector
@@ -65,7 +66,7 @@ target_include_directories(feature_detector
   ${EIGEN3_INCLUDE_DIRS}
 )
 
-add_executable(ekf src/ekf_node.cpp ${FILTER_SOURCES} ${MATH_SOURCES})
+add_executable(ekf src/ekf_node.cpp ${filter_src} ${math_src})
 ament_target_dependencies(ekf PUBLIC rclcpp std_msgs sensor_msgs cv_bridge image_transport)
 target_link_libraries(ekf PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog ${cpp_typesupport_target})
 target_include_directories(ekf
@@ -89,13 +90,13 @@ install(DIRECTORY
 )
 
 if(BUILD_TESTING)
-  file(GLOB_RECURSE TEST_SOURCES test/*.cpp)
-  file(GLOB_RECURSE SOURCES_FOR_TESTS src/*.cpp)
-  list(FILTER SOURCES_FOR_TESTS EXCLUDE REGEX "src/.*_node.cpp")
+  file(GLOB_RECURSE test_src test/*.cpp)
+  file(GLOB_RECURSE src_for_test src/*.cpp)
+  list(FILTER src_for_test EXCLUDE REGEX "src/.*_node.cpp")
 
   find_package(ament_cmake_gmock REQUIRED)
 
-  ament_add_gmock(some_test ${TEST_SOURCES} ${SOURCES_FOR_TESTS})
+  ament_add_gmock(some_test ${test_src} ${src_for_test})
   ament_target_dependencies(some_test std_msgs OpenCV)
   target_link_libraries(some_test spdlog::spdlog)
   target_include_directories(some_test PUBLIC

--- a/src/ekf-mono-slam/CMakeLists.txt
+++ b/src/ekf-mono-slam/CMakeLists.txt
@@ -30,16 +30,12 @@ file(GLOB_RECURSE visual_src src/visual/*.cpp)
 
 set(msg_files
   "msg/ImageFeatureMeasurement.msg"
+  "msg/ImageFeatureMeasurements.msg"
   "msg/ImageFeaturePrediction.msg"
-)
-
-set(srv_files
-  "srv/FeatureDetector.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
-  ${srv_files}
   DEPENDENCIES sensor_msgs
 )
 
@@ -56,7 +52,7 @@ target_include_directories(file_sequence_image
 )
 
 add_executable(feature_detector src/feature_detector_node.cpp ${feature_src} ${visual_src})
-ament_target_dependencies(feature_detector PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
+ament_target_dependencies(feature_detector PUBLIC rclcpp std_msgs sensor_msgs cv_bridge image_transport)
 target_link_libraries(feature_detector PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog ${cpp_typesupport_target})
 target_include_directories(feature_detector
   PUBLIC
@@ -67,7 +63,7 @@ target_include_directories(feature_detector
 )
 
 add_executable(ekf src/ekf_node.cpp ${filter_src} ${math_src})
-ament_target_dependencies(ekf PUBLIC rclcpp std_msgs sensor_msgs cv_bridge image_transport)
+ament_target_dependencies(ekf PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
 target_link_libraries(ekf PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog ${cpp_typesupport_target})
 target_include_directories(ekf
   PUBLIC

--- a/src/ekf-mono-slam/CMakeLists.txt
+++ b/src/ekf-mono-slam/CMakeLists.txt
@@ -62,7 +62,7 @@ target_include_directories(feature_detector
   ${EIGEN3_INCLUDE_DIRS}
 )
 
-add_executable(ekf src/ekf_node.cpp ${filter_src} ${math_src})
+add_executable(ekf src/ekf_node.cpp ${filter_src} ${math_src} ${feature_src} ${visual_src})
 ament_target_dependencies(ekf PUBLIC rclcpp std_msgs sensor_msgs cv_bridge)
 target_link_libraries(ekf PUBLIC ${OpenCV_LIBRARIES} spdlog::spdlog ${cpp_typesupport_target})
 target_include_directories(ekf

--- a/src/ekf-mono-slam/include/ekf_node.h
+++ b/src/ekf-mono-slam/include/ekf_node.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "ekf_mono_slam/srv/feature_detector.hpp"
+#include "ekf_mono_slam/msg/image_feature_measurements.hpp"
 #include "filter/ekf.h"
-#include "image_transport/image_transport.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -13,9 +12,8 @@ class EKFNode : public rclcpp::Node {
   ~EKFNode() = default;
 
  private:
-  std::shared_ptr<image_transport::Subscriber> image_subscriber_;
-  rclcpp::Client<ekf_mono_slam::srv::FeatureDetector>::SharedPtr detect_client_;
+  rclcpp::Subscription<ekf_mono_slam::msg::ImageFeatureMeasurements>::SharedPtr measurements_subscriber_;
   EKF ekf_;
 
-  void step_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg);
+  void step_callback(const ekf_mono_slam::msg::ImageFeatureMeasurements::ConstSharedPtr& msg);
 };

--- a/src/ekf-mono-slam/include/ekf_node.h
+++ b/src/ekf-mono-slam/include/ekf_node.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "filter/ekf.h"
 #include "image_transport/image_transport.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
@@ -12,6 +13,7 @@ class EKFNode : public rclcpp::Node {
 
  private:
   std::shared_ptr<image_transport::Subscriber> image_subscriber_;
+  EKF ekf_;
 
   void step_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg);
 };

--- a/src/ekf-mono-slam/include/ekf_node.h
+++ b/src/ekf-mono-slam/include/ekf_node.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ekf_mono_slam/srv/feature_detector.hpp"
 #include "filter/ekf.h"
 #include "image_transport/image_transport.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -13,6 +14,7 @@ class EKFNode : public rclcpp::Node {
 
  private:
   std::shared_ptr<image_transport::Subscriber> image_subscriber_;
+  rclcpp::Client<ekf_mono_slam::srv::FeatureDetector>::SharedPtr detect_client_;
   EKF ekf_;
 
   void step_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg);

--- a/src/ekf-mono-slam/include/feature/ellipse.h
+++ b/src/ekf-mono-slam/include/feature/ellipse.h
@@ -1,7 +1,6 @@
-#ifndef EKF_MONO_SLAM_ELLIPSE_H_
-#define EKF_MONO_SLAM_ELLIPSE_H_
+#pragma once
 
-#include <opencv2/opencv.hpp>
+#include "opencv2/opencv.hpp"
 
 class Ellipse final {
  public:
@@ -21,5 +20,3 @@ class Ellipse final {
   cv::Mat eigen_values_;
   cv::Mat eigen_vectors_;
 };
-
-#endif /* EKF_MONO_SLAM_ELLIPSE_H_ */

--- a/src/ekf-mono-slam/include/feature/feature_detector.h
+++ b/src/ekf-mono-slam/include/feature/feature_detector.h
@@ -1,15 +1,13 @@
-#ifndef EKF_MONO_SLAM_FEATURE_DETECTOR_H_
-#define EKF_MONO_SLAM_FEATURE_DETECTOR_H_
+#pragma once
 
 #include <spdlog/spdlog.h>
-
-#include <opencv2/core/types.hpp>
-#include <opencv2/features2d.hpp>
 
 #include "descriptor_extractor_type.h"
 #include "detector_type.h"
 #include "image_feature_measurement.h"
 #include "image_feature_prediction.h"
+#include "opencv2/core/types.hpp"
+#include "opencv2/features2d.hpp"
 #include "zone.h"
 
 class FeatureDetector final {
@@ -33,10 +31,9 @@ class FeatureDetector final {
 
   [[nodiscard]] cv::Size GetImageSize() const { return img_size_; }
 
-  void DetectFeatures(const cv::Mat& image, bool visualize = false);
+  void DetectFeatures(const cv::Mat& image);
 
-  void DetectFeatures(const cv::Mat& image, const std::vector<std::shared_ptr<ImageFeaturePrediction>>& predictions,
-                      bool visualize = false);
+  void DetectFeatures(const cv::Mat& image, const std::vector<std::shared_ptr<ImageFeaturePrediction>>& predictions);
 
  private:
   std::vector<std::shared_ptr<ImageFeatureMeasurement>> image_features_;
@@ -66,5 +63,3 @@ class FeatureDetector final {
 
   void SelectImageMeasurementsFromZones(std::list<std::shared_ptr<Zone>>& zones, const cv::Mat& image_mask);
 };
-
-#endif /* EKF_MONO_SLAM_FEATURE_DETECTOR_H_ */

--- a/src/ekf-mono-slam/include/feature/image_feature.h
+++ b/src/ekf-mono-slam/include/feature/image_feature.h
@@ -1,7 +1,7 @@
 #ifndef EKF_MONO_SLAM_IMAGE_FEATURE_H_
 #define EKF_MONO_SLAM_IMAGE_FEATURE_H_
 
-#include <opencv4/opencv2/core/types.hpp>
+#include "opencv2/opencv.hpp"
 
 class ImageFeature {
  public:

--- a/src/ekf-mono-slam/include/feature/image_feature.h
+++ b/src/ekf-mono-slam/include/feature/image_feature.h
@@ -12,7 +12,9 @@ class ImageFeature {
 
   [[nodiscard]] virtual cv::Point2f GetCoordinates() const { return coordinates_; }
 
-  [[nodiscard]] virtual int ComputeZone(int zone_width, int zone_height, int image_width, int image_height) const;
+  [[nodiscard]] virtual int GetFeatureIndex() const { return feature_index_; }
+
+  [[nodiscard]] virtual int ComputeZone(int zone_width, int zone_height, int image_width) const;
 
  protected:
   cv::Point2f coordinates_;

--- a/src/ekf-mono-slam/include/feature/image_feature_measurement.h
+++ b/src/ekf-mono-slam/include/feature/image_feature_measurement.h
@@ -1,5 +1,4 @@
-#ifndef EKF_MONO_SLAM_IMAGE_FEATURE_MEASUREMENT_H_
-#define EKF_MONO_SLAM_IMAGE_FEATURE_MEASUREMENT_H_
+#pragma once
 
 #include <opencv2/opencv.hpp>
 
@@ -24,5 +23,3 @@ class ImageFeatureMeasurement final : public ImageFeature {
  private:
   cv::Mat descriptor_data_;
 };
-
-#endif /* EKF_MONO_SLAM_IMAGE_FEATURE_MEASUREMENT_H_ */

--- a/src/ekf-mono-slam/include/feature/image_feature_measurement.h
+++ b/src/ekf-mono-slam/include/feature/image_feature_measurement.h
@@ -8,6 +8,7 @@
 class ImageFeatureMeasurement final : public ImageFeature {
  public:
   ImageFeatureMeasurement(cv::Point2f coordinates, const cv::Mat& descriptor_data);
+
   ImageFeatureMeasurement(const ImageFeatureMeasurement& source) = delete;
   ImageFeatureMeasurement(ImageFeatureMeasurement&& source) noexcept = delete;
 

--- a/src/ekf-mono-slam/include/feature/image_feature_prediction.h
+++ b/src/ekf-mono-slam/include/feature/image_feature_prediction.h
@@ -1,11 +1,12 @@
-#ifndef EKF_MONO_SLAM_IMAGE_FEATURE_PREDICTION_H_
-#define EKF_MONO_SLAM_IMAGE_FEATURE_PREDICTION_H_
+#pragma once
 
 #include "image_feature.h"
 
 class ImageFeaturePrediction final : public ImageFeature {
  public:
-  explicit ImageFeaturePrediction(cv::Mat covariance_matrix);
+  explicit ImageFeaturePrediction(cv::Point coordinates, cv::Mat covariance_matrix);
+  explicit ImageFeaturePrediction(cv::Point coordinates, cv::Mat covariance_matrix, int feature_index);
+
   ~ImageFeaturePrediction() override = default;
 
   cv::Mat& GetCovarianceMatrix() { return covariance_matrix_; }
@@ -13,5 +14,3 @@ class ImageFeaturePrediction final : public ImageFeature {
  private:
   cv::Mat covariance_matrix_;
 };
-
-#endif /* EKF_MONO_SLAM_IMAGE_FEATURE_PREDICTION_H_ */

--- a/src/ekf-mono-slam/include/feature_detector_node.h
+++ b/src/ekf-mono-slam/include/feature_detector_node.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ekf_mono_slam/srv/feature_detector.hpp"
+#include "filter/ekf.h"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+class FeatureDetectorNode : public rclcpp::Node {
+ public:
+  FeatureDetectorNode();
+  ~FeatureDetectorNode() = default;
+
+ private:
+  rclcpp::Service<ekf_mono_slam::srv::FeatureDetector>::SharedPtr service_;
+
+  void detect_callback(const std::shared_ptr<ekf_mono_slam::srv::FeatureDetector::Request> request,
+                       std::shared_ptr<ekf_mono_slam::srv::FeatureDetector::Response> response);
+};

--- a/src/ekf-mono-slam/include/feature_detector_node.h
+++ b/src/ekf-mono-slam/include/feature_detector_node.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "ekf_mono_slam/srv/feature_detector.hpp"
+#include "ekf_mono_slam/msg/image_feature_measurements.hpp"
 #include "filter/ekf.h"
+#include "image_transport/image_transport.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
 
@@ -11,8 +12,8 @@ class FeatureDetectorNode : public rclcpp::Node {
   ~FeatureDetectorNode() = default;
 
  private:
-  rclcpp::Service<ekf_mono_slam::srv::FeatureDetector>::SharedPtr service_;
+  std::shared_ptr<image_transport::Subscriber> image_subscriber_;
+  rclcpp::Publisher<ekf_mono_slam::msg::ImageFeatureMeasurements>::SharedPtr image_measurements_publisher_;
 
-  void detect_callback(const std::shared_ptr<ekf_mono_slam::srv::FeatureDetector::Request> request,
-                       std::shared_ptr<ekf_mono_slam::srv::FeatureDetector::Response> response);
+  void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg);
 };

--- a/src/ekf-mono-slam/include/filter/ekf.h
+++ b/src/ekf-mono-slam/include/filter/ekf.h
@@ -20,6 +20,8 @@ class EKF final {
   EKF& operator=(EKF const& source) = delete;
   EKF& operator=(EKF&& source) noexcept = delete;
 
+  std::shared_ptr<FeatureDetector> GetFeatureDetector() const { return feature_detector_; }
+
   void Init(const cv::Mat& image);
   void Step(const cv::Mat& image);
 
@@ -29,10 +31,9 @@ class EKF final {
  private:
   std::shared_ptr<CovarianceMatrix> covariance_matrix_;
   std::shared_ptr<State> state_;
+  std::shared_ptr<FeatureDetector> feature_detector_;
   int step_;
   double delta_t_;
-
-  std::unique_ptr<FeatureDetector> feature_detector_;
 
   void AddFeatures(const std::vector<std::shared_ptr<ImageFeatureMeasurement>>& features) const;
 };

--- a/src/ekf-mono-slam/include/filter/ekf.h
+++ b/src/ekf-mono-slam/include/filter/ekf.h
@@ -20,7 +20,13 @@ class EKF final {
   EKF& operator=(EKF const& source) = delete;
   EKF& operator=(EKF&& source) noexcept = delete;
 
+  std::shared_ptr<State> GetState() const { return state_; }
+
   std::shared_ptr<FeatureDetector> GetFeatureDetector() const { return feature_detector_; }
+
+  bool isInitilized() const {
+    return state_->GetDepthFeatures().size() != 0 || state_->GetInverseDepthFeatures().size() != 0;
+  }
 
   void Init(const cv::Mat& image);
   void Step(const cv::Mat& image);
@@ -28,14 +34,14 @@ class EKF final {
   void PredictMeasurementState();
   void PredictMeasurementCovariance();
 
+  void AddFeatures(const std::vector<std::shared_ptr<ImageFeatureMeasurement>>& features) const;
+
  private:
   std::shared_ptr<CovarianceMatrix> covariance_matrix_;
   std::shared_ptr<State> state_;
   std::shared_ptr<FeatureDetector> feature_detector_;
   int step_;
   double delta_t_;
-
-  void AddFeatures(const std::vector<std::shared_ptr<ImageFeatureMeasurement>>& features) const;
 };
 
 #endif /* EKF_MONO_SLAM_EKF_H */

--- a/src/ekf-mono-slam/include/visual/visual.h
+++ b/src/ekf-mono-slam/include/visual/visual.h
@@ -1,10 +1,9 @@
-#ifndef EKF_MONO_SLAM_VISUAL_H_
-#define EKF_MONO_SLAM_VISUAL_H_
+#pragma once
 
-#include <opencv4/opencv2/opencv.hpp>
 #include <vector>
 
-#include "ellipse.h"
+#include "feature/ellipse.h"
+#include "opencv2/opencv.hpp"
 
 namespace Visual {
 void UncertaintyEllipse2D(const cv::Mat& image, Ellipse& ellipse, int max_axes_size, const cv::Scalar& color,
@@ -12,5 +11,3 @@ void UncertaintyEllipse2D(const cv::Mat& image, Ellipse& ellipse, int max_axes_s
 
 void VisualizeKeyPoints(const cv::Mat& image, const std::vector<cv::KeyPoint>& keypoints);
 }  // namespace Visual
-
-#endif /* EKF_MONO_SLAM_VISUAL_H_ */

--- a/src/ekf-mono-slam/launch/vslam.launch.py
+++ b/src/ekf-mono-slam/launch/vslam.launch.py
@@ -11,7 +11,7 @@ def generate_launch_description():
                 "image_dir", default_value="./resources/desk_translation/"
             ),
             Node(
-                package="ekf-mono-slam",
+                package="ekf_mono_slam",
                 executable="file_sequence_image",
                 name="file_sequence_image",
                 namespace="slam",

--- a/src/ekf-mono-slam/launch/vslam.launch.py
+++ b/src/ekf-mono-slam/launch/vslam.launch.py
@@ -21,13 +21,13 @@ def generate_launch_description():
                 ],
                 arguments=["--ros-args", "--log-level", "warn"],
             ),
-            Node(
-                package="ekf_mono_slam",
-                executable="ekf",
-                name="ekf",
-                namespace="slam",
-                output="screen",
-                arguments=["--ros-args", "--log-level", "warn"],
-            ),
+            # Node(
+            #     package="ekf_mono_slam",
+            #     executable="ekf",
+            #     name="ekf",
+            #     namespace="slam",
+            #     output="screen",
+            #     arguments=["--ros-args", "--log-level", "warn"],
+            # ),
         ]
     )

--- a/src/ekf-mono-slam/launch/vslam.launch.py
+++ b/src/ekf-mono-slam/launch/vslam.launch.py
@@ -21,5 +21,13 @@ def generate_launch_description():
                 ],
                 arguments=["--ros-args", "--log-level", "warn"],
             ),
+            Node(
+                package="ekf_mono_slam",
+                executable="ekf",
+                name="ekf",
+                namespace="slam",
+                output="screen",
+                arguments=["--ros-args", "--log-level", "warn"],
+            ),
         ]
     )

--- a/src/ekf-mono-slam/launch/vslam.launch.py
+++ b/src/ekf-mono-slam/launch/vslam.launch.py
@@ -21,13 +21,13 @@ def generate_launch_description():
                 ],
                 arguments=["--ros-args", "--log-level", "warn"],
             ),
-            # Node(
-            #     package="ekf_mono_slam",
-            #     executable="ekf",
-            #     name="ekf",
-            #     namespace="slam",
-            #     output="screen",
-            #     arguments=["--ros-args", "--log-level", "warn"],
-            # ),
+            Node(
+                package="ekf_mono_slam",
+                executable="ekf",
+                name="ekf",
+                namespace="slam",
+                output="screen",
+                arguments=["--ros-args", "--log-level", "warn"],
+            ),
         ]
     )

--- a/src/ekf-mono-slam/msg/ImageFeatureMeasurement.msg
+++ b/src/ekf-mono-slam/msg/ImageFeatureMeasurement.msg
@@ -1,4 +1,4 @@
-int32 x
-int32 y
+float32 x
+float32 y
 uint8[] descriptor
 int32 feature_index

--- a/src/ekf-mono-slam/msg/ImageFeatureMeasurement.msg
+++ b/src/ekf-mono-slam/msg/ImageFeatureMeasurement.msg
@@ -1,0 +1,4 @@
+int32 x
+int32 y
+uint8[] descriptor
+int32 feature_index

--- a/src/ekf-mono-slam/msg/ImageFeatureMeasurements.msg
+++ b/src/ekf-mono-slam/msg/ImageFeatureMeasurements.msg
@@ -1,0 +1,1 @@
+ekf_mono_slam/ImageFeatureMeasurement[] features

--- a/src/ekf-mono-slam/msg/ImageFeaturePrediction.msg
+++ b/src/ekf-mono-slam/msg/ImageFeaturePrediction.msg
@@ -1,0 +1,4 @@
+int32 x
+int32 y
+uint8[] covariance_matrix
+int32 feature_index

--- a/src/ekf-mono-slam/msg/ImageFeaturePrediction.msg
+++ b/src/ekf-mono-slam/msg/ImageFeaturePrediction.msg
@@ -1,4 +1,4 @@
-int32 x
-int32 y
+float32 x
+float32 y
 uint8[] covariance_matrix
 int32 feature_index

--- a/src/ekf-mono-slam/package.xml
+++ b/src/ekf-mono-slam/package.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>ekf-mono-slam</name>
+  <name>ekf_mono_slam</name>
   <version>0.1.0</version>
   <description>Visual Mono SLAM with 1-Point RANSAC EKF</description>
   <maintainer email="alvgaona@gmail.com">Alvaro J. Gaona</maintainer>
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>sensor_msgs</depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/ekf-mono-slam/src/ekf_node.cpp
+++ b/src/ekf-mono-slam/src/ekf_node.cpp
@@ -12,7 +12,12 @@ EKFNode::EKFNode() : Node("ekf_node") {
 void EKFNode::step_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg) {
   cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
   cv::Mat image = cv_ptr->image;
-  RCLCPP_INFO(this->get_logger(), "Image size '%d'", image.size().width);
+
+  // if (ekf_.GetFeatureDetector() == nullptr) {
+  //   ekf_.Init(image);
+  // }
+
+  // ekf_.Step(image);
 }
 
 int main(int argc, char* argv[]) {

--- a/src/ekf-mono-slam/src/ekf_node.cpp
+++ b/src/ekf-mono-slam/src/ekf_node.cpp
@@ -3,13 +3,34 @@
 #include <memory>
 
 #include "cv_bridge/cv_bridge.h"
+#include "feature/image_feature_measurement.h"
 
 EKFNode::EKFNode() : Node("ekf_node") {
   measurements_subscriber_ = this->create_subscription<ekf_mono_slam::msg::ImageFeatureMeasurements>(
       "features/image/measurements", 10, std::bind(&EKFNode::step_callback, this, std::placeholders::_1));
 }
 
-void EKFNode::step_callback(const ekf_mono_slam::msg::ImageFeatureMeasurements::ConstSharedPtr& msg) {}
+void EKFNode::step_callback(const ekf_mono_slam::msg::ImageFeatureMeasurements::ConstSharedPtr& msg) {
+  std::vector<std::shared_ptr<ImageFeatureMeasurement>> features;
+
+  for (auto im_feature_mes : msg->features) {
+    const auto descriptor_size = im_feature_mes.descriptor.size();
+    auto descriptor = cv::Mat(1, descriptor_size, CV_8UC1, im_feature_mes.descriptor.data());
+
+    // TODO: do I need the feature index at this point or later?
+    features.push_back(
+        std::make_shared<ImageFeatureMeasurement>(cv::Point2f(im_feature_mes.x, im_feature_mes.y), descriptor));
+  }
+
+  if (!ekf_.isInitilized()) {
+    ekf_.AddFeatures(features);
+
+    std::cout << ekf_.GetState()->GetInverseDepthFeatures().size() << std::endl;
+    return;
+  }
+
+  // TODO: do step
+}
 
 int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);

--- a/src/ekf-mono-slam/src/ekf_node.cpp
+++ b/src/ekf-mono-slam/src/ekf_node.cpp
@@ -5,33 +5,11 @@
 #include "cv_bridge/cv_bridge.h"
 
 EKFNode::EKFNode() : Node("ekf_node") {
-  image_subscriber_ = std::make_shared<image_transport::Subscriber>(image_transport::create_subscription(
-      this, "camera/image", std::bind(&EKFNode::step_callback, this, std::placeholders::_1), "raw"));
-  detect_client_ = this->create_client<ekf_mono_slam::srv::FeatureDetector>("feature_detect");
+  measurements_subscriber_ = this->create_subscription<ekf_mono_slam::msg::ImageFeatureMeasurements>(
+      "features/image/measurements", 10, std::bind(&EKFNode::step_callback, this, std::placeholders::_1));
 }
 
-void EKFNode::step_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg) {
-  cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
-  cv::Mat image = cv_ptr->image;
-
-  auto request = std::make_shared<ekf_mono_slam::srv::FeatureDetector::Request>();
-  request->image = *msg;
-
-  auto future_response = detect_client_->async_send_request(request);
-
-  auto status = future_response.wait_for(std::chrono::seconds(5));
-
-  if (status == std::future_status::ready) {
-    auto response = future_response.get();
-    RCLCPP_INFO(this->get_logger(), "Total number of features: '%d'", response->features.size());
-  }
-
-  // if (ekf_.GetFeatureDetector() == nullptr) {
-  //   ekf_.Init(image);
-  // }
-
-  // ekf_.Step(image);
-}
+void EKFNode::step_callback(const ekf_mono_slam::msg::ImageFeatureMeasurements::ConstSharedPtr& msg) {}
 
 int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);

--- a/src/ekf-mono-slam/src/ekf_node.cpp
+++ b/src/ekf-mono-slam/src/ekf_node.cpp
@@ -7,11 +7,24 @@
 EKFNode::EKFNode() : Node("ekf_node") {
   image_subscriber_ = std::make_shared<image_transport::Subscriber>(image_transport::create_subscription(
       this, "camera/image", std::bind(&EKFNode::step_callback, this, std::placeholders::_1), "raw"));
+  detect_client_ = this->create_client<ekf_mono_slam::srv::FeatureDetector>("feature_detect");
 }
 
 void EKFNode::step_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg) {
   cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
   cv::Mat image = cv_ptr->image;
+
+  auto request = std::make_shared<ekf_mono_slam::srv::FeatureDetector::Request>();
+  request->image = *msg;
+
+  auto future_response = detect_client_->async_send_request(request);
+
+  auto status = future_response.wait_for(std::chrono::seconds(5));
+
+  if (status == std::future_status::ready) {
+    auto response = future_response.get();
+    RCLCPP_INFO(this->get_logger(), "Total number of features: '%d'", response->features.size());
+  }
 
   // if (ekf_.GetFeatureDetector() == nullptr) {
   //   ekf_.Init(image);

--- a/src/ekf-mono-slam/src/feature/ellipse.cpp
+++ b/src/ekf-mono-slam/src/feature/ellipse.cpp
@@ -1,4 +1,4 @@
-#include "visual/ellipse.h"
+#include "feature/ellipse.h"
 
 #include "math/ekf_math.h"
 

--- a/src/ekf-mono-slam/src/feature/feature_detector.cpp
+++ b/src/ekf-mono-slam/src/feature/feature_detector.cpp
@@ -165,13 +165,12 @@ void FeatureDetector::GroupFeaturesAndPredictionsByZone(
     const std::vector<cv::KeyPoint>& keypoints, const cv::Mat& descriptors) const {
   const auto keypoints_size = keypoints.size();
 
-  for (auto i = 0; i < keypoints_size; i++) {
+  for (auto i = 0U; i < keypoints_size; i++) {
     const cv::KeyPoint& keypoint = keypoints.at(i);
 
     const auto image_feature_measurement = std::make_shared<ImageFeatureMeasurement>(keypoint.pt, descriptors.row(i));
 
-    const int zone_id =
-        image_feature_measurement->ComputeZone(zone_size_.width, zone_size_.height, img_size_.width, img_size_.height);
+    const int zone_id = image_feature_measurement->ComputeZone(zone_size_.width, zone_size_.height, img_size_.width);
 
     zones[zone_id]->AddCandidate(image_feature_measurement);
     int candidates_left = zones[zone_id]->GetCandidatesLeft();
@@ -180,9 +179,8 @@ void FeatureDetector::GroupFeaturesAndPredictionsByZone(
 
   const auto predictions_size = predictions.size();
 
-  for (auto i = 0; i < predictions_size; i++) {
-    const int zone_id =
-        predictions[i]->ComputeZone(zone_size_.width, zone_size_.height, img_size_.width, img_size_.height);
+  for (auto i = 0U; i < predictions_size; i++) {
+    const int zone_id = predictions[i]->ComputeZone(zone_size_.width, zone_size_.height, img_size_.width);
 
     zones[zone_id]->AddPrediction(predictions[i]);
     int predictions_features_count = zones[zone_id]->GetPredictionsFeaturesCount();
@@ -250,7 +248,7 @@ void FeatureDetector::ComputeImageFeatureMeasurements(
     const std::vector<cv::KeyPoint>& image_keypoints) {
   if (const auto keypoints_size = image_keypoints.size();
       keypoints_size <= ImageFeatureParameters::features_per_image) {
-    for (int i = 0; i < keypoints_size; i++) {
+    for (auto i = 0U; i < keypoints_size; i++) {
       const cv::KeyPoint& keypoint = image_keypoints[i];
       image_features_.emplace_back(std::make_unique<ImageFeatureMeasurement>(keypoint.pt, descriptors.row(i)));
     }

--- a/src/ekf-mono-slam/src/feature/feature_detector.cpp
+++ b/src/ekf-mono-slam/src/feature/feature_detector.cpp
@@ -58,7 +58,6 @@ void FeatureDetector::DetectFeatures(const cv::Mat& image,
   BuildImageMask(image_mask, predictions);
 
   std::vector<cv::KeyPoint> image_keypoints;
-  spdlog::info("Detecting keypoints");
   detector_->detect(image, image_keypoints, image_mask);
   spdlog::debug("Number of keypoints detected: {}", image_keypoints.size());
 

--- a/src/ekf-mono-slam/src/feature/feature_detector.cpp
+++ b/src/ekf-mono-slam/src/feature/feature_detector.cpp
@@ -1,9 +1,11 @@
 #include "feature/feature_detector.h"
 
 #include <configuration/image_feature_parameters.h>
-#include <visual/visual.h>
 
 #include <random>
+
+#include "feature/ellipse.h"
+#include "visual/visual.h"
 
 /**
  * @brief Construct a FeatureDetector object.
@@ -50,8 +52,7 @@ FeatureDetector::FeatureDetector(const cv::Ptr<cv::FeatureDetector>& detector,
  * accessed later.
  */
 void FeatureDetector::DetectFeatures(const cv::Mat& image,
-                                     const std::vector<std::shared_ptr<ImageFeaturePrediction>>& predictions,
-                                     const bool visualize) {
+                                     const std::vector<std::shared_ptr<ImageFeaturePrediction>>& predictions) {
   const cv::Mat image_mask(cv::Mat::ones(image.rows, image.cols, CV_8UC1) * 255);
 
   BuildImageMask(image_mask, predictions);
@@ -60,10 +61,6 @@ void FeatureDetector::DetectFeatures(const cv::Mat& image,
   spdlog::info("Detecting keypoints");
   detector_->detect(image, image_keypoints, image_mask);
   spdlog::debug("Number of keypoints detected: {}", image_keypoints.size());
-
-  if (visualize) {
-    Visual::VisualizeKeyPoints(image, image_keypoints);
-  }
 
   cv::Mat descriptors;
   extractor_->compute(image, image_keypoints, descriptors);
@@ -82,9 +79,9 @@ void FeatureDetector::DetectFeatures(const cv::Mat& image,
  * (recommended for most cases), the function will use an empty set of predictions internally.
  * Additionally, the function offers the option to visualize the detected keypoints on the image for debugging purposes.
  */
-void FeatureDetector::DetectFeatures(const cv::Mat& image, const bool visualize) {
+void FeatureDetector::DetectFeatures(const cv::Mat& image) {
   const std::vector<std::shared_ptr<ImageFeaturePrediction>> empty_predictions;
-  DetectFeatures(image, empty_predictions, visualize);
+  DetectFeatures(image, empty_predictions);
 }
 
 /**

--- a/src/ekf-mono-slam/src/feature/image_feature.cpp
+++ b/src/ekf-mono-slam/src/feature/image_feature.cpp
@@ -36,7 +36,6 @@ ImageFeature::ImageFeature(const cv::Point2f coordinates, const int feature_inde
  * @param zone_width The width of each zone in pixels.
  * @param zone_height The height of each zone in pixels.
  * @param image_width The width of the entire image in pixels.
- * @param image_height The height of the entire image in pixels.
  * @return The zone ID for the image feature.
  *
  * This function calculates the zone ID for a given `ImageFeature` object based on its coordinates and the provided zone
@@ -49,8 +48,7 @@ ImageFeature::ImageFeature(const cv::Point2f coordinates, const int feature_inde
  * This method allows for efficient organization and retrieval of features and predictions associated with specific
  * zones within the image.
  */
-int ImageFeature::ComputeZone(const int zone_width, const int zone_height, const int image_width,
-                              const int image_height) const {
+int ImageFeature::ComputeZone(const int zone_width, const int zone_height, const int image_width) const {
   const int zone_x = static_cast<int>(coordinates_.x) / zone_width;
   const int zone_y = static_cast<int>(coordinates_.y) / zone_height;
   return zone_y * (image_width / zone_width) + zone_x;

--- a/src/ekf-mono-slam/src/feature/image_feature_prediction.cpp
+++ b/src/ekf-mono-slam/src/feature/image_feature_prediction.cpp
@@ -1,0 +1,11 @@
+#include "feature/image_feature_prediction.h"
+
+ImageFeaturePrediction::ImageFeaturePrediction(cv::Point coordinates, cv::Mat covariance_matrix)
+    : ImageFeature(coordinates) {
+  covariance_matrix_ = covariance_matrix;
+}
+
+ImageFeaturePrediction::ImageFeaturePrediction(cv::Point coordinates, cv::Mat covariance_matrix, int feature_index)
+    : ImageFeature(coordinates, feature_index) {
+  covariance_matrix_ = covariance_matrix;
+}

--- a/src/ekf-mono-slam/src/feature/undistorted_image_feature.cpp
+++ b/src/ekf-mono-slam/src/feature/undistorted_image_feature.cpp
@@ -28,7 +28,7 @@ Eigen::Vector3d UndistortedImageFeature::BackProject() const {
   // doi: 10.1007/978-3-642-24834-4.
   const double x = -(coordinates_.x() - cx) * dx / fx;
   const double y = -(coordinates_.y() - cy) * dy / fy;
-  constexpr double z = 1.0L;
+  constexpr double z = 1L;
 
   return {x, y, z};
 }

--- a/src/ekf-mono-slam/src/feature_detector_node.cpp
+++ b/src/ekf-mono-slam/src/feature_detector_node.cpp
@@ -2,6 +2,7 @@
 
 #include "cv_bridge/cv_bridge.h"
 #include "feature/feature_detector.h"
+#include "spdlog/spdlog.h"
 
 FeatureDetectorNode::FeatureDetectorNode() : Node("feature_detector") {
   image_subscriber_ = std::make_shared<image_transport::Subscriber>(image_transport::create_subscription(
@@ -30,7 +31,8 @@ void FeatureDetectorNode::image_callback(const sensor_msgs::msg::Image::ConstSha
     feature.feature_index = m->GetFeatureIndex();
     feature.x = coordinates.x;
     feature.y = coordinates.y;
-    feature.descriptor.assign(descriptor.datastart, descriptor.dataend);
+
+    descriptor.copyTo(feature.descriptor);
 
     image_feature_measurements.features.push_back(feature);
   }

--- a/src/ekf-mono-slam/src/feature_detector_node.cpp
+++ b/src/ekf-mono-slam/src/feature_detector_node.cpp
@@ -19,9 +19,9 @@ void FeatureDetectorNode::detect_callback(const std::shared_ptr<ekf_mono_slam::s
                                    FeatureDetector::BuildDescriptorExtractor(DescriptorExtractorType::AKAZE),
                                    cv::Size(image.rows, image.cols));
 
-  feature_detector.DetectFeatures(image, false);
+  feature_detector.DetectFeatures(image);
 
-  RCLCPP_INFO(this->get_logger(), "Image size '%d'", image.size().width);
+  // RCLCPP_INFO(this->get_logger(), "Image size '%d'", image.size().width);
 }
 
 int main(int argc, char *argv[]) {

--- a/src/ekf-mono-slam/src/feature_detector_node.cpp
+++ b/src/ekf-mono-slam/src/feature_detector_node.cpp
@@ -1,0 +1,32 @@
+#include "feature_detector_node.h"
+
+#include "cv_bridge/cv_bridge.h"
+#include "feature/feature_detector.h"
+
+FeatureDetectorNode::FeatureDetectorNode() : Node("feature_detector") {
+  service_ = this->create_service<ekf_mono_slam::srv::FeatureDetector>(
+      "feature_detect",
+      std::bind(&FeatureDetectorNode::detect_callback, this, std::placeholders::_1, std::placeholders::_2));
+}
+
+void FeatureDetectorNode::detect_callback(const std::shared_ptr<ekf_mono_slam::srv::FeatureDetector::Request> request,
+                                          std::shared_ptr<ekf_mono_slam::srv::FeatureDetector::Response> response) {
+  auto image_msg = request->image;
+  cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(image_msg, sensor_msgs::image_encodings::BGR8);
+  cv::Mat image = cv_ptr->image;
+
+  FeatureDetector feature_detector(FeatureDetector::BuildDetector(DetectorType::AKAZE),
+                                   FeatureDetector::BuildDescriptorExtractor(DescriptorExtractorType::AKAZE),
+                                   cv::Size(image.rows, image.cols));
+
+  feature_detector.DetectFeatures(image, false);
+
+  RCLCPP_INFO(this->get_logger(), "Image size '%d'", image.size().width);
+}
+
+int main(int argc, char *argv[]) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<FeatureDetectorNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/ekf-mono-slam/src/file_sequence_image_node.cpp
+++ b/src/ekf-mono-slam/src/file_sequence_image_node.cpp
@@ -16,7 +16,7 @@ FileSequenceImageNode::FileSequenceImageNode() : Node("file_sequence_image") {
   image_provider_ = std::make_unique<FileSequenceImageProvider>(image_dir, 1, 359);
   image_publisher_ =
       std::make_shared<image_transport::Publisher>(image_transport::create_publisher(this, "camera/image"));
-  timer_ = this->create_wall_timer(40ms, std::bind(&FileSequenceImageNode::timer_callback, this));
+  timer_ = this->create_wall_timer(1000ms, std::bind(&FileSequenceImageNode::timer_callback, this));
 }
 
 void FileSequenceImageNode::timer_callback() {

--- a/src/ekf-mono-slam/src/filter/ekf.cpp
+++ b/src/ekf-mono-slam/src/filter/ekf.cpp
@@ -32,7 +32,7 @@ void EKF::Init(const cv::Mat& image) {
       FeatureDetector::BuildDetector(DetectorType::AKAZE),
       FeatureDetector::BuildDescriptorExtractor(DescriptorExtractorType::AKAZE), cv::Size(image.rows, image.cols));
 
-  feature_detector_->DetectFeatures(image, false);
+  feature_detector_->DetectFeatures(image);
 
   AddFeatures(feature_detector_->GetImageFeatures());
 }

--- a/src/ekf-mono-slam/srv/FeatureDetector.srv
+++ b/src/ekf-mono-slam/srv/FeatureDetector.srv
@@ -1,0 +1,3 @@
+sensor_msgs/Image image
+---
+ImageFeatureMeasurement[] features

--- a/src/ekf-mono-slam/srv/FeatureDetector.srv
+++ b/src/ekf-mono-slam/srv/FeatureDetector.srv
@@ -1,4 +1,0 @@
-sensor_msgs/Image image
-ImageFeaturePrediction[] predictions
----
-ImageFeatureMeasurement[] features

--- a/src/ekf-mono-slam/srv/FeatureDetector.srv
+++ b/src/ekf-mono-slam/srv/FeatureDetector.srv
@@ -1,3 +1,4 @@
 sensor_msgs/Image image
+ImageFeaturePrediction[] predictions
 ---
 ImageFeatureMeasurement[] features

--- a/src/ekf-mono-slam/test/utest_feature.cpp
+++ b/src/ekf-mono-slam/test/utest_feature.cpp
@@ -62,11 +62,11 @@ TEST(Zones, AddFeature) {
 TEST(Zones, ComputeZone) {
   const cv::Mat descriptor = cv::Mat::zeros(cv::Size(30, 30), CV_64FC1);
   const ImageFeatureMeasurement feature1(cv::Point2f(0, 0), descriptor);
-  ASSERT_EQ(feature1.ComputeZone(480, 270, 1920, 1080), 0);
+  ASSERT_EQ(feature1.ComputeZone(480, 270, 1920), 0);
 
   const ImageFeatureMeasurement feature2(cv::Point2f(1900, 1000), descriptor);
-  ASSERT_EQ(feature2.ComputeZone(480, 270, 1920, 1080), 15);
+  ASSERT_EQ(feature2.ComputeZone(480, 270, 1920), 15);
 
   const ImageFeatureMeasurement feature3(cv::Point2f(959, 271), descriptor);
-  ASSERT_EQ(feature3.ComputeZone(480, 270, 1920, 1080), 5);
+  ASSERT_EQ(feature3.ComputeZone(480, 270, 1920), 5);
 }

--- a/src/ekf-mono-slam/test/utest_feature.cpp
+++ b/src/ekf-mono-slam/test/utest_feature.cpp
@@ -24,7 +24,7 @@ TEST(FeatureDetectors, NotSupportedDetector) {
 }
 
 TEST(FeatureDetectors, DetectFeatures) {
-  FileSequenceImageProvider image_provider("./src/ekf-mono-slam//test/resources/desk_translation/");
+  FileSequenceImageProvider image_provider("./src/ekf_mono_slam/test/resources/desk_translation/");
   const cv::Mat image = image_provider.GetNextImage();
 
   FeatureDetector detector(FeatureDetector::BuildDetector(DetectorType::BRISK),

--- a/src/ekf-mono-slam/test/utest_image.cpp
+++ b/src/ekf-mono-slam/test/utest_image.cpp
@@ -2,13 +2,13 @@
 #include "image/file_sequence_image_provider.h"
 
 TEST(FileSequenceImageProvider, InitFileSequenceImageProvider) {
-  FileSequenceImageProvider image_provider("./src/ekf-mono-slam/test/resources/desk_translation/");
+  FileSequenceImageProvider image_provider("./src/ekf_mono_slam/test/resources/desk_translation/");
 
   ASSERT_EQ(image_provider.GetImageCounter(), 0);
 }
 
 TEST(FileSequenceImageProvider, GetFirstImage) {
-  FileSequenceImageProvider image_provider("./src/ekf-mono-slam/test/resources/desk_translation/");
+  FileSequenceImageProvider image_provider("./src/ekf_mono_slam/test/resources/desk_translation/");
 
   cv::Mat image = image_provider.GetNextImage();
 
@@ -18,7 +18,7 @@ TEST(FileSequenceImageProvider, GetFirstImage) {
 }
 
 TEST(FileSequenceProvider, NoMoreImagesInDirectory) {
-  FileSequenceImageProvider image_provider("./src/ekf-mono-slam/test/resources/desk_translation/", 2, 2);
+  FileSequenceImageProvider image_provider("./src/ekf_mono_slam/test/resources/desk_translation/", 2, 2);
   cv::Mat image = image_provider.GetNextImage();
   auto size = image.size();
 


### PR DESCRIPTION
- Ignore `resources/` dir
- Change project name format
- Add custom messages
- The EKF node subscribes to an image feature measurements topic
- Feature detector node subscribes to the camera image topic and publishes the image feature measurements.
- Detect if EKF is initialized to add features without predictions.